### PR TITLE
Update README.md fixed small error

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Values are 2-complement int16_t, MSB first. All channels are identical.
 ### Example
 Value | Measurement
 ----|-----------
- `0xFC 0x17` | -1000 mG
+ `0xFC 0x18` | -1000 mG
  `0x03 0xE8` | 1000 mG
 
 ## Battery voltage


### PR DESCRIPTION
The acceleration example for 2-complement value where wrong. It should be "0xFC 0x18" not "0xFC 0X17".
Fixes Issue #12 